### PR TITLE
:bug: fix missing `pyarrow.dataset` import for `pyarrow 13.0.0`

### DIFF
--- a/dagster_polars/io_managers/parquet.py
+++ b/dagster_polars/io_managers/parquet.py
@@ -5,6 +5,7 @@ import fsspec
 import polars as pl
 import pyarrow as pa
 import pyarrow.parquet
+import pyarrow.dataset
 from dagster import InputContext, OutputContext
 from pyarrow import Table
 from upath import UPath

--- a/dagster_polars/io_managers/parquet.py
+++ b/dagster_polars/io_managers/parquet.py
@@ -4,8 +4,8 @@ from typing import Optional, Union
 import fsspec
 import polars as pl
 import pyarrow as pa
-import pyarrow.parquet
 import pyarrow.dataset
+import pyarrow.parquet
 from dagster import InputContext, OutputContext
 from pyarrow import Table
 from upath import UPath


### PR DESCRIPTION
This is an attempt to fix #37.